### PR TITLE
chore: remove PR labels step from workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -46,7 +46,6 @@ jobs:
             - Includes daily boss chances JSON under `data/<World>/<YYYY-MM-DD>.json`.
           branch: chore/data-update
           delete-branch: true
-          labels: automated, data-update
           signoff: false
 
       # Enable auto-merge on the PR (requires repo setting "Allow auto-merge" enabled)


### PR DESCRIPTION
This PR removes the step that attempted to set labels on pull requests during the automated update workflow.
Since this repository doesn’t have the required permissions to manage labels via GitHub Actions, the step has been removed to prevent workflow failures.